### PR TITLE
Not opening browser and running parallel requests in background

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,21 +1,34 @@
-import webbrowser
+import threading
+import time
+from statistics import mean, median
 import requests
 
 rbc_url = 'https://www.dav-rbc.de/072/185829.php'
-MAX_OPEN_WEBSITE = 5
+PARALLEL_REQUESTS = 5
+RUNS = 5
 
-# webbrowser.open(rbc_url)
-i=0
+_c1, _c = 6, 21
 
-while i <= 10:
-    #Open Website in default browser MAX_OPEN_WEBSITE times
-    j=1
-    while j <= MAX_OPEN_WEBSITE:
-        webbrowser.open(rbc_url)
-        j=j+1
-    #Send GET request and print time
-    response = requests.get(rbc_url).elapsed.total_seconds()
-    i=i+1
-    print(response)
+print(f'{"Run".ljust(_c1)} | {"T to Headers".ljust(_c+1)} | {"T to complete Request".ljust(_c+2)}')
+print(f'{"-"* (_c1 + 1)}+{"-"* (_c + 3)}+{"-" * (_c + 2)}')
+t1s, t2s = [], []
+for run in range(1, RUNS+1):
+    # run all PARALLEL_REQUESTS except one in a background thread to simulate multiple users requesting the site
+    for p in range(PARALLEL_REQUESTS - 1):
+        threading.Thread(target=lambda: requests.get(rbc_url), daemon=True)
+    # use the only other request to measure time
+    start = time.time()
+    t1 = requests.get(rbc_url).elapsed.total_seconds()
+    t2 = time.time() - start
+    print(f'{str(run).rjust(_c1)} | {str(round(t1, 3)).rjust(_c)}s | {str(round(t2, 3)).rjust(_c)}s')
+    t1s.append(t1)
+    t2s.append(t2)
 
-print ("Danke")
+if RUNS > 1:
+    print(f'{"-"* (_c1 + 1)}+{"-"* (_c + 3)}+{"-" * (_c + 2)}')
+    print(f'{"MIN".rjust(_c1)} | {str(round(min(t1s), 3)).rjust(_c)}s | {str(round(min(t2s), 3)).rjust(_c)}s')
+    print(f'{"MEDIAN".rjust(_c1)} | {str(round(median(t1s), 3)).rjust(_c)}s | {str(round(median(t2s), 3)).rjust(_c)}s')
+    print(f'{"AVG".rjust(_c1)} | {str(round(mean(t1s), 3)).rjust(_c)}s | {str(round(mean(t2s), 3)).rjust(_c)}s')
+    print(f'{"MAX".rjust(_c1)} | {str(round(max(t1s), 3)).rjust(_c)}s | {str(round(max(t2s), 3)).rjust(_c)}s')
+
+print("\nDanke")


### PR DESCRIPTION
To ease measuring the script was changed to use requests only and not opening browser windows for the parallel requests. One can change the amount of background requests with  `PARALLEL_REQUESTS` and the number of runs with `RUNS`. If more than one run is scheduled the average, median, min and max timings are calculated. Furthermore the script distinguishes
 between sending the request to the first time the headers can be parsed (`t1`) and the download of the complete payload of the response (`t2`).